### PR TITLE
[INFRASTRUCTURE] Make clientid public

### DIFF
--- a/src/lib/connection/MqttConnection.ts
+++ b/src/lib/connection/MqttConnection.ts
@@ -17,7 +17,7 @@ export class MqttConnection {
 
     private readonly listener: IListener;
     private readonly renderer: IRenderer;
-    private readonly clientId: string;
+    public readonly clientId: string;
     private readonly identityId: string;
     private readonly userId: string;
     private readonly mqttClient: mqtt.MqttClient;


### PR DESCRIPTION
Knowing the clientid is necessary for convey users of this release, because in multi connection scenarios EventType.create(type:EventType, clientId: string) must be called.