### PR TITLE
[GAIA-2263] Adjust usage of publishConvInteraction to sdk version 2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "license": "MIT",
     "author": "Leftshift One Software GmbH <core-devs@leftshift.one>",
     "dependencies": {
-        "@leftshiftone/gaia-sdk": "^2.0.4",
+        "@leftshiftone/gaia-sdk": "^2.1.0",
         "@zxing/library": "^0.12.4",
         "browser-image-compression": "^1.0.6",
         "d3": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "license": "MIT",
     "author": "Leftshift One Software GmbH <core-devs@leftshift.one>",
     "dependencies": {
-        "@leftshiftone/gaia-sdk": "^2.0.3",
+        "@leftshiftone/gaia-sdk": "^2.0.4",
         "@zxing/library": "^0.12.4",
         "browser-image-compression": "^1.0.6",
         "d3": "^5.8.0",

--- a/src/lib/connection/Subscription.ts
+++ b/src/lib/connection/Subscription.ts
@@ -6,6 +6,7 @@ import EventStream from "../event/EventStream";
 import {EventType} from "../event/EventType";
 import {IEventPayload} from "../api/IEvent";
 import {MultiTargetRenderer} from "../renderer/MultiTargetRenderer";
+import {MessageType} from "../support/MessageType";
 
 export class Subscription {
     public type: ConversationQueueType;
@@ -53,7 +54,7 @@ export class Subscription {
             this.bind(new KeyboardBehaviour(this.renderer));
             this.bind(new MouseBehaviour(this.renderer));
         }
-        this.mqttSensorQueue.publishConvInteraction(this.header, attributes);
+        this.mqttSensorQueue.publishConvInteraction(this.header, {attributes, payload: {}, type: MessageType.RECEPTION});
     }
 
     public onMessage(message: object) {


### PR DESCRIPTION
This PR is still waiting for https://github.com/leftshiftone/gaia-sdk/pull/56 to be merged & gaia sdk to be released.