### PR TITLE
[INFRA] Rating submission class and addition to std.ts

### DIFF
--- a/src/lib/renderable/rating/index.ts
+++ b/src/lib/renderable/rating/index.ts
@@ -90,6 +90,9 @@ export class Rating implements IRenderable, IStackeable {
             const type = MessageType.RATING;
             const evType = EventType.withChannelId(EventType.PUBLISH, this.spec.channelId);
             EventStream.emit(evType, {attributes, type, payload} as IEventPayload);
+
+            // Possibility to hide the rating container once it has been submitted
+            this.ratingContainer.addClasses("lto-rating-submitted");
         });
     }
 

--- a/src/lib/renderable/rating/style.scss
+++ b/src/lib/renderable/rating/style.scss
@@ -2,6 +2,5 @@
 }
 
 .lto-rating-submitted {
-    // For example: Hide the rating container once it has been submitted
-    // display: none;
+    display: none;
 }

--- a/src/lib/renderable/rating/style.scss
+++ b/src/lib/renderable/rating/style.scss
@@ -1,3 +1,7 @@
 .lto-rating {
 }
 
+.lto-rating-submitted {
+    // For example: Hide the rating container once it has been submitted
+    // display: none;
+}

--- a/src/std.ts
+++ b/src/std.ts
@@ -2,6 +2,7 @@ import {Gaia} from './lib/Gaia';
 import {ClassicRenderer} from './lib/renderer/ClassicRenderer';
 import {MultiTargetRenderer} from './lib/renderer/MultiTargetRenderer';
 import {ContentCentricRenderer} from './lib/renderer/ContentCentricRenderer';
+import {RatingRenderer} from './lib/renderer/RatingRenderer';
 import {RevealJsRenderer} from './lib/renderer/RevealJsRenderer';
 import {MouseBehaviour} from './lib/behaviour/MouseBehaviour';
 import {KeyboardBehaviour} from './lib/behaviour/KeyboardBehaviour';
@@ -60,6 +61,7 @@ export {
     MultiTargetRenderer,
     ClassicRenderer,
     ContentCentricRenderer,
+    RatingRenderer,
     RevealJsRenderer,
     Gaia,
     MouseBehaviour,


### PR DESCRIPTION
* The submission class makes it possible to hide the rating container once the rating has been submitted.
* The addition of RatingRenderer to std.ts is necessary in order to import it in other projects such as convey-starter.