### PR TITLE
[GAIA-2819] Fix undefined child in RatingDecorator if elements is empty

### DIFF
--- a/src/lib/renderer/__tests__/RatingDecorator.test.ts
+++ b/src/lib/renderer/__tests__/RatingDecorator.test.ts
@@ -39,7 +39,7 @@ describe("RatingDecorator test", () => {
         ["rating markup is not used & ratings are enabled by default", false, RatingRenderStrategy.ALL_EXCEPT_DISABLED_RATINGS],
     ]).it("render rating if %s", (title: string, withRatingMarkup: boolean, ratingRenderStrategy: RatingRenderStrategy) => {
         const renderer = new RatingDecorator(new ContentCentricRenderer(), ratingRenderStrategy);
-        const specification = RatingTestSpecGenerator.generate(withRatingMarkup, true);
+        const specification = RatingTestSpecGenerator.generate({withRatingMarkup, ratingEnabled: true});
 
         const rendered = renderer.render(specification);
 
@@ -51,7 +51,7 @@ describe("RatingDecorator test", () => {
         ["rating markup is not used & ratings are disabled by default", false, RatingRenderStrategy.ONLY_ENABLED_RATINGS],
     ]).it("do not render rating if %s", (title: string, withRatingMarkup: boolean, ratingRenderStrategy: RatingRenderStrategy) => {
         const renderer = new RatingDecorator(new ContentCentricRenderer(), ratingRenderStrategy);
-        const specification = RatingTestSpecGenerator.generate(withRatingMarkup, false);
+        const specification = RatingTestSpecGenerator.generate({withRatingMarkup, ratingEnabled: false});
 
         const rendered = renderer.render(specification);
 
@@ -60,7 +60,7 @@ describe("RatingDecorator test", () => {
 
     it("do not render rating if elements is empty", () => {
         const renderer = new RatingDecorator(new ContentCentricRenderer(), RatingRenderStrategy.ONLY_ENABLED_RATINGS);
-        const specification = RatingTestSpecGenerator.generate(false, false);
+        const specification = RatingTestSpecGenerator.generate({withRatingMarkup: false, ratingEnabled: false});
         specification["elements"] = [];
 
         const rendered = renderer.render(specification);
@@ -70,7 +70,7 @@ describe("RatingDecorator test", () => {
 
     it("do not render rating if enriched is incomplete", () => {
         const renderer = new RatingDecorator(new ContentCentricRenderer(), RatingRenderStrategy.ALL_EXCEPT_DISABLED_RATINGS);
-        const specification = RatingTestSpecGenerator.generate(true, true);
+        const specification = RatingTestSpecGenerator.generate({withRatingMarkup: true, ratingEnabled: true});
         delete specification["enriched"].nodeId;
 
         const rendered = renderer.render(specification);
@@ -80,7 +80,7 @@ describe("RatingDecorator test", () => {
 
     it("do not render rating if enriched does not exist", () => {
         const renderer = new RatingDecorator(new ContentCentricRenderer(), RatingRenderStrategy.ALL_EXCEPT_DISABLED_RATINGS);
-        const specification = RatingTestSpecGenerator.generate(true, true);
+        const specification = RatingTestSpecGenerator.generate({withRatingMarkup: true, ratingEnabled: true});
         delete specification["enriched"];
 
         const rendered = renderer.render(specification);
@@ -109,7 +109,7 @@ describe("RatingDecorator test", () => {
 });
 
 class RatingTestSpecGenerator {
-    static generate(withRatingMarkup: boolean, ratingEnabled: boolean) {
+    static generate(config: { withRatingMarkup: boolean, ratingEnabled: boolean }) {
         const content = [{
             class: "some-class",
             type: "block",
@@ -126,10 +126,10 @@ class RatingTestSpecGenerator {
             ]
         }];
 
-        if (withRatingMarkup) {
+        if (config.withRatingMarkup) {
             return RatingTestSpecGenerator.wrapInContainer([{
                 type: "rating",
-                enabled: ratingEnabled,
+                enabled: config.ratingEnabled,
                 elements: content
             }]);
         }

--- a/src/lib/renderer/__tests__/RatingDecorator.test.ts
+++ b/src/lib/renderer/__tests__/RatingDecorator.test.ts
@@ -58,6 +58,16 @@ describe("RatingDecorator test", () => {
         expectNotToBeRatingElement(rendered.pop());
     });
 
+    it("do not render rating if elements is empty", () => {
+        const renderer = new RatingDecorator(new ContentCentricRenderer(), RatingRenderStrategy.ONLY_ENABLED_RATINGS);
+        const specification = RatingTestSpecGenerator.generate(false, false);
+        specification["elements"] = [];
+
+        const rendered = renderer.render(specification);
+
+        expectNotToBeRatingElement(rendered.pop());
+    });
+
     it("do not render rating if enriched is incomplete", () => {
         const renderer = new RatingDecorator(new ContentCentricRenderer(), RatingRenderStrategy.ALL_EXCEPT_DISABLED_RATINGS);
         const specification = RatingTestSpecGenerator.generate(true, true);

--- a/src/lib/renderer/decorator/RatingDecorator.ts
+++ b/src/lib/renderer/decorator/RatingDecorator.ts
@@ -46,7 +46,8 @@ export class RatingDecorator extends AbstractDecorator {
         if (parentContainer) return false;
         if (!RatingDecorator.isRootContainerOfInteraction(renderable)) return false;
 
-        const child = (renderable.elements || [{type: undefined, enabled: undefined}])[0];
+        const child = (renderable.elements || [undefined])[0] || {type: undefined, enabled: undefined};
+
         return (child.type === "rating" && child.enabled === true)
             || (this.renderStrategy === RatingRenderStrategy.ALL_EXCEPT_DISABLED_RATINGS && child.enabled !== false);
 


### PR DESCRIPTION


If the elements array is empty, child was undefined and child.type was called leading to an error.

Now child cannot be undefined anymore.